### PR TITLE
ReadExecutionPath で読込中にエラーが発生するとファイルを開いたままになる

### DIFF
--- a/cmd/nswitchcov_a/main.go
+++ b/cmd/nswitchcov_a/main.go
@@ -71,6 +71,8 @@ func ReadExecutionPath(fileName string, encode string) ([][]string, error) {
 	if err != nil {
 		panic(err)
 	}
+	defer func() { _ = fp.Close() }()
+
 	var scanner *bufio.Scanner
 	if encode == "utf8" {
 		scanner = bufio.NewScanner(fp)
@@ -129,7 +131,6 @@ func ReadExecutionPath(fileName string, encode string) ([][]string, error) {
 		exePath = append(exePath, tempExePath)
 	}
 
-	defer fp.Close()
 	return exePath, nil
 }
 


### PR DESCRIPTION
`ReadExecutionPath` 関数でファイルを開いた後すぐに `defer fp.Close()` が実行されないので、ファイル読み込み中にエラーが発生した場合、ファイルが閉じられない状態になっているようだったので修正しました